### PR TITLE
Fix task ENV variables definition

### DIFF
--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
@@ -187,7 +187,7 @@ public class AndroidEmulatorPlugin implements Plugin<Project> {
                                        final String name,
                                        final Action<AbstractExecTask<Exec>> configure) {
         return project.getTasks().create(name, Exec.class, (final Exec task) -> {
-            task.setEnvironment(emulatorConfiguration.getEnvironmentVariableMap());
+            task.environment(emulatorConfiguration.getEnvironmentVariableMap());
 
             configure.execute(task);
 


### PR DESCRIPTION
Fix task env variables definition as setEnvironment() will replace all original system variables so i.e. JAVA_HOME is missing. environmane()  just adds new variables while keeping the originals.

Fixes #7 