### PR TITLE
Allow plugin to work with SDK which belongs to another user

### DIFF
--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
@@ -65,18 +65,22 @@ public class AndroidEmulatorPlugin implements Plugin<Project> {
                 });
     }
 
+    private static boolean ensureFileIsExecutable(final File file) {
+        return file.canExecute() || file.setExecutable(true);
+    }
+
     private static void createEnsurePermissionsTask(final Project project, final EmulatorConfiguration emulatorConfiguration) {
         project.getTasks().create(ENSURE_ANDROID_EMULATOR_PERMISSIONS_TASK_NAME, task -> {
             task.doFirst(t -> {
-                if (!emulatorConfiguration.getSdkManager().setExecutable(true)) {
+                if (!ensureFileIsExecutable(emulatorConfiguration.getSdkManager())) {
                     throw new RuntimeException("Unable to make SDK Manager executable");
                 }
 
-                if (!emulatorConfiguration.getAvdManager().setExecutable(true)) {
+                if (!ensureFileIsExecutable(emulatorConfiguration.getAvdManager())) {
                     throw new RuntimeException("Unable to make Android Virtual Device manager executable");
                 }
 
-                if (!emulatorConfiguration.getAdb().setExecutable(true)) {
+                if (!ensureFileIsExecutable(emulatorConfiguration.getAdb())) {
                     throw new RuntimeException(("Unable to make ADB executable"));
                 }
             });

--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorPlugin.java
@@ -65,7 +65,15 @@ public class AndroidEmulatorPlugin implements Plugin<Project> {
                 });
     }
 
+    /**
+     * Ensures given file is executable, and if not, tries promote file to be executable
+     *
+     * @return true, if file is executable
+     */
     private static boolean ensureFileIsExecutable(final File file) {
+        // First check if file is executable. In most environments sdk binaries are already executable.
+        // In some environments your process is not an owner of the file and can't change permission.
+        // For example docker or CI
         return file.canExecute() || file.setExecutable(true);
     }
 


### PR DESCRIPTION
The current implementation does not work if SDK belongs to another user (for example root) even it is executable. This is a typical case of a docker container.

After this fix, the plugin will work if you have permission to run SDK or if you own SDK. 