### PR TITLE
Update log4j to 2.15.0

### DIFF
--- a/android-emulator-plugin/build.gradle
+++ b/android-emulator-plugin/build.gradle
@@ -65,7 +65,7 @@ pluginBundle {
 dependencies {
     implementation 'com.android.tools.build:gradle:4.1.0'
     implementation 'commons-io:commons-io:2.8.0'
-    implementation 'org.apache.logging.log4j:log4j-iostreams:2.14.0'
+    implementation 'org.apache.logging.log4j:log4j-iostreams:2.15.0'
 
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     testCompileOnly 'com.google.code.findbugs:annotations:3.0.1'


### PR DESCRIPTION
Fix security issue: CVE-2021-44228

https://logging.apache.org/log4j/2.x/#News

Actually, it is the only plugin in my build environment that uses log4j.