### PR TITLE
Remove unused dependencies

### DIFF
--- a/android-emulator-plugin/build.gradle
+++ b/android-emulator-plugin/build.gradle
@@ -64,8 +64,6 @@ pluginBundle {
 
 dependencies {
     implementation 'com.android.tools.build:gradle:4.1.0'
-    implementation 'commons-io:commons-io:2.8.0'
-    implementation 'org.apache.logging.log4j:log4j-iostreams:2.15.0'
 
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     testCompileOnly 'com.google.code.findbugs:annotations:3.0.1'


### PR DESCRIPTION
I was just curious, why do you need log4j and try to delete dependencies. Everything works just fine. Is it not a big deal, just good hygiene. 