### PR TITLE
Bug descendant proc is not termitated

### DIFF
--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/ProcessDestroyer.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/ProcessDestroyer.java
@@ -24,7 +24,7 @@ class ProcessDestroyer implements UnaryOperator<Process> {
     @Override
     public Process apply(final Process process) {
         if (process != null) {
-			List<ProcessHandle> descendants = process.descendants().collect(Collectors.toList());
+            List<ProcessHandle> descendants = process.descendants().collect(Collectors.toList());
             // Use a non-forceful destroy first to allow the process to gracefully shutdown. With the android emulator
             // this includes creating a snapshot of the current state for warm boots in subsequent runs. On unix-like
             // systems this usually translates to raising a SIGTERM signal.
@@ -38,8 +38,8 @@ class ProcessDestroyer implements UnaryOperator<Process> {
                     process.destroyForcibly();
                     process.waitFor(PROCESS_TERMINATION_TIMEOUT_SEC, TimeUnit.SECONDS);
                 }
-				// if a process has not destroyed descendants
-				descendants.forEach(ProcessHandle::destroyForcibly);
+                // if a process has not destroyed descendants
+                descendants.forEach(ProcessHandle::destroyForcibly);
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for process to be destroyed", e);
                 // It is likely fine to allow the failure and move on. The termination of the gradle process might stop


### PR DESCRIPTION
It is the a bug fix of the following problem. 
The android gradle plugin starts an emulator which starts decedent process such as qemu-system-x86_64.exe on Windows 10 Home x86_64. The plugin stops the emulator, but the emulator does not stop qemu-system-x86_64. qemu-system-x86_64 works in background as a zombie process. It might be a bug of the emulator, but a termination of all decedents of emulator fix this problem. 