### PR TITLE
feature: adding sdkmanager common arguments

### DIFF
--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorExtension.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/AndroidEmulatorExtension.java
@@ -85,6 +85,7 @@ public class AndroidEmulatorExtension {
     private boolean enableForAndroidTests = true;
     private boolean headless = false;
     private String[] additionalEmulatorArguments = null;
+    private String[] additionalSdkManagerArguments = null;
     private boolean logEmulatorOutput = false;
 
     public EmulatorExtension getEmulator() {
@@ -147,8 +148,28 @@ public class AndroidEmulatorExtension {
         this.additionalEmulatorArguments = toArray(additionalEmulatorArguments);
     }
 
+    public void additionalSdkManagerArguments(final String[] additionalSdkManagerArguments) {
+        this.additionalSdkManagerArguments = clone(additionalSdkManagerArguments);
+    }
+
+    public void additionalSdkManagerArguments(final Collection<String> additionalSdkManagerArguments) {
+        this.additionalSdkManagerArguments = toArray(additionalSdkManagerArguments);
+    }
+
+    public void setAdditionalSdkManagerArguments(final String[] additionalSdkManagerArguments) {
+        this.additionalSdkManagerArguments = clone(additionalSdkManagerArguments);
+    }
+
+    public void setAdditionalSdkManagerArguments(final Collection<String> additionalSdkManagerArguments) {
+        this.additionalSdkManagerArguments = toArray(additionalSdkManagerArguments);
+    }
+
     public String[] getAdditionalEmulatorArguments() {
         return clone(this.additionalEmulatorArguments);
+    }
+
+    public String[] getAdditionalSdkManagerArguments() {
+        return clone(this.additionalSdkManagerArguments);
     }
 
     public void logEmulatorOutput(final boolean logEmulatorOutput) {

--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/EmulatorConfiguration.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/EmulatorConfiguration.java
@@ -43,6 +43,7 @@ public class EmulatorConfiguration {
     private final Map<String, String> environmentVariableMap;
     private final boolean enableForAndroidTests;
     private final List<String> additionalEmulatorArguments;
+    private final List<String> additionalSdkManagerArguments;
     private final boolean logEmulatorOutput;
     private final String androidVersion;
     private final String flavor;
@@ -81,9 +82,17 @@ public class EmulatorConfiguration {
             additionalEmulatorArguments.add("-no-audio");
             additionalEmulatorArguments.add("-no-window");
         }
-        final String[] additionalArgs = androidEmulatorExtension.getAdditionalEmulatorArguments();
-        if (additionalArgs != null) {
-            additionalEmulatorArguments.addAll(Arrays.asList(additionalArgs));
+        final String[] additionalEmulatorArgs = androidEmulatorExtension.getAdditionalEmulatorArguments();
+        if (additionalEmulatorArgs != null) {
+            additionalEmulatorArguments.addAll(Arrays.asList(additionalEmulatorArgs));
+        }
+
+        final String[] additionalSdkManagerArgs = androidEmulatorExtension.getAdditionalSdkManagerArguments();
+        if (additionalSdkManagerArgs != null) {
+            additionalSdkManagerArguments = new ArrayList<>();
+            additionalSdkManagerArguments.addAll(Arrays.asList(additionalSdkManagerArgs));
+        } else {
+            additionalSdkManagerArguments = Collections.emptyList();
         }
 
         this.logEmulatorOutput = androidEmulatorExtension.getLogEmulatorOutput();
@@ -218,6 +227,10 @@ public class EmulatorConfiguration {
 
     public List<String> getAdditionalEmulatorArguments() {
         return additionalEmulatorArguments;
+    }
+
+    public List<String> getAdditionalSdkManagerArguments() {
+        return additionalSdkManagerArguments;
     }
 
     public boolean getLogEmulatorOutput() {

--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/InstallAndroidEmulatorSystemImageTask.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/InstallAndroidEmulatorSystemImageTask.java
@@ -11,7 +11,8 @@ public class InstallAndroidEmulatorSystemImageTask extends AndroidEmulatorBaseEx
         super(InstallAndroidEmulatorSystemImageTask.class, emulatorConfiguration);
 
         this.setExecutable(emulatorConfiguration.getCmdLineToolsSdkManager());
-        this.setArgs(Arrays.asList(buildSdkRootArgument(), emulatorConfiguration.getSystemImagePackageName()));
+        this.args(Arrays.asList(buildSdkRootArgument(), emulatorConfiguration.getSystemImagePackageName()));
+        this.args(emulatorConfiguration.getAdditionalSdkManagerArguments());
         this.setStandardInput(buildStandardInLines("y"));
         this.getOutputs().dir(emulatorConfiguration.sdkFile("system-images", emulatorConfiguration.getAndroidVersion(), emulatorConfiguration.getFlavor(), emulatorConfiguration.getAbi()));
         this.getOutputs().file(emulatorConfiguration.sdkFile("system-images", emulatorConfiguration.getAndroidVersion(), emulatorConfiguration.getFlavor(), emulatorConfiguration.getAbi(), "system.img"));

--- a/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/InstallSdkDependenciesTask.java
+++ b/android-emulator-plugin/src/main/java/com/quittle/androidemulator/task/InstallSdkDependenciesTask.java
@@ -14,7 +14,8 @@ public class InstallSdkDependenciesTask extends AndroidEmulatorBaseExecTask<Inst
         super(InstallSdkDependenciesTask.class, emulatorConfiguration);
 
         this.setExecutable(emulatorConfiguration.getSdkManager());
-        this.setArgs(Arrays.asList(buildSdkRootArgument(), "emulator", "cmdline-tools;latest", "platform-tools"));
+        this.args(Arrays.asList(buildSdkRootArgument(), "emulator", "cmdline-tools;latest", "platform-tools"));
+        this.args(emulatorConfiguration.getAdditionalSdkManagerArguments());
         this.setStandardInput(buildStandardInLines("y"));
         this.getOutputs().dir(new File(emulatorConfiguration.getSdkRoot(), "emulator"));
 


### PR DESCRIPTION
adding sdkmanager common arguments in DSL:

> sdkmanager --help
> Common Arguments:
>     --proxy=<http | socks>: Connect via a proxy of the given type.
>     --proxy_host=<IP or DNS address>: IP or DNS address of the proxy to use.
>     --proxy_port=<port #>: Proxy port to connect to.
>     --verbose: Enable verbose output.