### PR TITLE
Fix #187: Fix Android Gradle Dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,14 @@ workflows:
           matrix:
             parameters:
               test_suite:
+                - 1
                 - 2
                 - 3
-                # - 4 # Currently broken
                 - 5
                 - 6
                 - 7
                 - 8
                 - 9
-                - 10
           filters:
             tags:
               only: /.*/

--- a/android-emulator-plugin/build.gradle
+++ b/android-emulator-plugin/build.gradle
@@ -58,14 +58,20 @@ pluginBundle {
 }
 
 dependencies {
-    implementation 'com.android.tools.build:gradle:7.3.0'
-    implementation 'com.android.tools:common:30.3.0'
+    compileOnly 'com.android.tools:common:30.3.0'
+    def ANDROID_GRADLE_PLUGIN_VERSION = '7.3.0'
+    compileOnly "com.android.tools.build:gradle:$ANDROID_GRADLE_PLUGIN_VERSION"
     implementation 'commons-io:commons-io:2.8.0'
 
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     testCompileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
     testImplementation 'io.mockk:mockk:1.12.8'
+    testImplementation "com.android.tools.build:gradle:$ANDROID_GRADLE_PLUGIN_VERSION"
+
+    // implementation 'com.android.tools:common:30.3.0'
+
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.8.0'
 }

--- a/example-android-project/build.gradle
+++ b/example-android-project/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     final Map<String, String> env = System.getenv()
-    project.ext.ANDROID_GRADLE_VERSION = env.getOrDefault('ANDROID_GRADLE_VERSION', '3.2.1')
-    project.ext.ANDROID_GRADLE_VERSION_NEW = Boolean.valueOf(env.getOrDefault('ANDROID_GRADLE_VERSION_NEW', 'true'))
+    project.ext.ANDROID_GRADLE_VERSION = env.getOrDefault('ANDROID_GRADLE_VERSION', '7.0.0')
     project.ext.ANDROID_EMULATOR_SDK_VERSION = Integer.valueOf(env.getOrDefault('ANDROID_EMULATOR_SDK_VERSION', '21'))
     project.ext.ANDROID_EMULATOR_GOOGLE_APIS = Boolean.valueOf(env.getOrDefault('ANDROID_EMULATOR_GOOGLE_APIS', 'false'))
     project.ext.ANDROID_EMULATOR_ABI = env.getOrDefault('ANDROID_EMULATOR_ABI', 'x86')
@@ -45,24 +44,17 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
-    if (ANDROID_GRADLE_VERSION_NEW) {
-        testOptions {
-            execution 'ANDROIDX_TEST_ORCHESTRATOR'
-        }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     useLibrary 'android.test.runner'
 }
 
 dependencies {
-    if (ANDROID_GRADLE_VERSION_NEW) {
-        androidTestImplementation 'androidx.test:runner:1.3.0'
-        androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-        androidTestUtil 'androidx.test:orchestrator:1.3.0'
-    } else {
-        androidTestCompile 'androidx.test:runner:1.3.0'
-        androidTestCompile 'androidx.test.ext:junit:1.1.2'
-    }
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestUtil 'androidx.test:orchestrator:1.3.0'
 }
 
 androidEmulator {

--- a/validate_plugin
+++ b/validate_plugin
@@ -38,12 +38,12 @@ export ADB_INSTALL_TIMEOUT=10
 # Add additional gradle options for testing
 export GRADLE_OPTS="${GRADLE_OPTS} -Dorg.gradle.logging.level=info"
 
-# Run the test on the default (for the project) emulator as well as using the new Gradle plugin with an older SDK version
+# Run the test on the default (for the project) emulator as well as using an older SDK version
 # Run one after the other to ensure the plugin handles changing of configuration.
 if should_run_target 1; then
     ./gradlew -p example-android-project connectedCheck
     kill_emulator
-    ANDROID_GRADLE_VERSION=3.2.1 ANDROID_GRADLE_VERSION_NEW=true ANDROID_EMULATOR_SDK_VERSION=21 ./gradlew -p example-android-project connectedCheck
+    ANDROID_EMULATOR_SDK_VERSION=21 ./gradlew -p example-android-project connectedCheck
 fi
 
 # Use a google_apis flavor
@@ -58,23 +58,18 @@ if should_run_target 3; then
         echo 'Build failure expected due to "No connected devices!"'
 fi
 
-# Use the old Gradle plugin
-if should_run_target 4; then
-    ANDROID_GRADLE_VERSION=2.3.3 ANDROID_GRADLE_VERSION_NEW=false ANDROID_EMULATOR_GOOGLE_APIS=true ANDROID_EMULATOR_SDK_VERSION=24 ./gradlew -p example-android-project connectedCheck
-fi
-
 # Use a newer version of Gradle plugin
-if should_run_target 5; then
-    ANDROID_GRADLE_VERSION=3.4.0 ANDROID_GRADLE_VERSION_NEW=true ANDROID_EMULATOR_GOOGLE_APIS=true ANDROID_EMULATOR_SDK_VERSION=24 ./gradlew -p example-android-project connectedCheck
+if should_run_target 4; then
+    ANDROID_GRADLE_VERSION=7.1.0 ANDROID_EMULATOR_GOOGLE_APIS=true ANDROID_EMULATOR_SDK_VERSION=24 ./gradlew -p example-android-project connectedCheck
 fi
 
 # Use the logEmulatorOutput flag
-if should_run_target 6; then
+if should_run_target 5; then
     LOG_ANDROID_EMULATOR=true ANDROID_EMULATOR_SDK_VERSION=24 ANDROID_EMULATOR_GOOGLE_APIS=true ./gradlew -p example-android-project connectedCheck
 fi
 
 # Use the failed emulator starts don't hang forever
-if should_run_target 7; then
+if should_run_target 6; then
     FAIL_EMULATOR_STARTUP=true ./gradlew -p example-android-project assemble # Prove the flag doesn't fail the build
     FAIL_EMULATOR_STARTUP=true ./gradlew -p example-android-project connectedCheck &&
         echo 'Build should not have succeeded' && exit 1 ||
@@ -82,16 +77,16 @@ if should_run_target 7; then
 fi
 
 # Use the emulator's device field by specifying the device type
-if should_run_target 8; then
+if should_run_target 7; then
     ANDROID_EMULATOR_SDK_VERSION=24 ANDROID_EMULATOR_DEVICE=pixel_xl ./gradlew -p example-android-project connectedCheck
 fi
 
 # Use the device field by specifying the device code
-if should_run_target 9; then
+if should_run_target 8; then
     ANDROID_EMULATOR_SDK_VERSION=24 ANDROID_EMULATOR_DEVICE=19 ./gradlew -p example-android-project connectedCheck
 fi
 
 # Use the latest Gradle plugin
-if should_run_target 10; then
-    ANDROID_GRADLE_VERSION=4.0.1 ANDROID_GRADLE_VERSION_NEW=true ANDROID_EMULATOR_GOOGLE_APIS=true ANDROID_EMULATOR_SDK_VERSION=24 ./gradlew -p example-android-project connectedCheck
+if should_run_target 9; then
+    ANDROID_GRADLE_VERSION=7.3.0 ANDROID_EMULATOR_GOOGLE_APIS=true ANDROID_EMULATOR_SDK_VERSION=24 ./gradlew -p example-android-project connectedCheck
 fi


### PR DESCRIPTION
Update how Android Gradle dependency works, revealing a bunch of broken version. Currently only 7.0.0 and above work with the latest Gradle versions and this plugin